### PR TITLE
feat: capacity-safe office expansion + ownership durability

### DIFF
--- a/src/AgentHabitat.Core/WorldGen/Implementation/DeterministicWorldGenerator.cs
+++ b/src/AgentHabitat.Core/WorldGen/Implementation/DeterministicWorldGenerator.cs
@@ -77,7 +77,21 @@ public sealed class DeterministicWorldGenerator : IWorldGenerator
                 return candidate;
         }
 
-        return null; // Could not place — world is too full
+        return null; // Could not place — caller should expand world and retry
+    }
+
+    // Capacity expansion: determine minimum world size to fit N offices + shared rooms
+    public static (int Width, int Height) ComputeRequiredSize(int sharedRoomCount, int officeCount, int baseWidth = 32, int baseHeight = 24)
+    {
+        // Each office needs ~35 tiles (5x7) + corridor space (~10 tiles)
+        // Shared rooms need ~80 tiles (10x8) each + corridor space
+        var totalArea = sharedRoomCount * 120 + officeCount * 60;
+        // Target ~40% fill ratio for comfortable placement
+        var requiredArea = (int)(totalArea / 0.4);
+        var side = (int)Math.Ceiling(Math.Sqrt(requiredArea));
+        var width = Math.Max(baseWidth, Math.Min(96, side));
+        var height = Math.Max(baseHeight, Math.Min(72, (int)(side * 0.75)));
+        return (width, height);
     }
 
     private static IEnumerable<RoomPlacement> PlaceRooms(SeededRng rng, WorldGenerationOptions options)

--- a/src/AgentHabitat.Web/Services/WorldService.cs
+++ b/src/AgentHabitat.Web/Services/WorldService.cs
@@ -39,12 +39,9 @@ public class WorldService
         IReadOnlyList<AgentDefinition>? agents = null)
     {
         var agentList = agents ?? DefaultAgents;
-        // Scale world to fit shared rooms + private offices
-        var baseWidth = 32;
-        var baseHeight = 24;
-        var extraSpace = agentList.Count * 3; // ~3 tiles per office width contribution
-        var width = Math.Min(64, baseWidth + extraSpace);
-        var height = Math.Min(48, baseHeight + extraSpace / 2);
+        // Compute world size based on room + office count
+        var (width, height) = DeterministicWorldGenerator.ComputeRequiredSize(
+            sharedRoomCount: 4, officeCount: agentList.Count);
 
         var options = new WorldGenerationOptions(
             Width: width,

--- a/tests/AgentHabitat.Core.Tests/WorldGenerationTests.cs
+++ b/tests/AgentHabitat.Core.Tests/WorldGenerationTests.cs
@@ -311,6 +311,63 @@ public class WorldGenerationTests
     }
 
     [Fact]
+    public void GeneratedWorld_CapacityExpansion_FitsEightAgents()
+    {
+        var agents = Enumerable.Range(1, 8)
+            .Select(i => new AgentDefinition($"agent-{i}", $"Agent {i}", "Developer"))
+            .ToArray();
+        var (w, h) = DeterministicWorldGenerator.ComputeRequiredSize(4, agents.Length);
+        var opts = new WorldGenerationOptions(w, h, 1, WorldStyleProfiles.RetroOffice, "v1", agents);
+        var world = _gen.GenerateWorld("capacity-test", opts);
+
+        // All 8 agents should have offices
+        foreach (var agent in agents)
+        {
+            Assert.Contains(world.Rooms, r => r.Id == $"office-{agent.Id}");
+        }
+        // Plus 4 shared rooms
+        Assert.Equal(12, world.Rooms.Count);
+
+        var errors = WorldValidation.Validate(world);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ComputeRequiredSize_ScalesWithAgentCount()
+    {
+        var (w1, h1) = DeterministicWorldGenerator.ComputeRequiredSize(4, 2);
+        var (w2, h2) = DeterministicWorldGenerator.ComputeRequiredSize(4, 8);
+        var (w3, h3) = DeterministicWorldGenerator.ComputeRequiredSize(4, 16);
+
+        // More agents = larger world
+        Assert.True(w2 * h2 > w1 * h1, "8 agents should need more space than 2");
+        Assert.True(w3 * h3 > w2 * h2, "16 agents should need more space than 8");
+        // Stays within bounds
+        Assert.True(w3 <= 96 && h3 <= 72, "Should not exceed max bounds");
+    }
+
+    [Fact]
+    public void OwnershipMap_NoDuplicates_AcrossSeeds()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            var agents = Enumerable.Range(1, 6)
+                .Select(j => new AgentDefinition($"a-{j}", $"Agent {j}", "Developer"))
+                .ToArray();
+            var (w, h) = DeterministicWorldGenerator.ComputeRequiredSize(4, agents.Length);
+            var opts = new WorldGenerationOptions(w, h, 1, WorldStyleProfiles.RetroOffice, "v1", agents);
+            var world = _gen.GenerateWorld($"own-{i:000}", opts);
+
+            var officeIds = agents.Select(a => $"office-{a.Id}").ToList();
+            var foundOffices = world.Rooms.Where(r => officeIds.Contains(r.Id)).ToList();
+
+            // Each agent has exactly one office, no dupes
+            Assert.Equal(agents.Length, foundOffices.Count);
+            Assert.Equal(foundOffices.Count, foundOffices.Select(r => r.Id).Distinct().Count());
+        }
+    }
+
+    [Fact]
     public void SeedPack_WritesHashSamplesArtifact_ForAlphaAndExtendedSeeds()
     {
         var seeds = new[] { "alpha-001", "alpha-002", "alpha-003", "beta-001", "gamma-001" };


### PR DESCRIPTION
## Summary
- Add `ComputeRequiredSize()` for dynamic world scaling based on agent count
- Targets ~40% fill ratio, caps at 96x72 max world size
- Replaces ad-hoc scaling in WorldService
- 3 new tests: capacity expansion (8 agents), size scaling, ownership no-dupes (20-seed sweep)

Closes #5

## Test plan
- [x] 32/32 tests pass
- [x] 8-agent capacity test: all agents get offices + validation pass
- [x] Size computation monotonically increases with agent count
- [x] No duplicate ownership across 20 seeds × 6 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)