### PR TITLE
docs: consolidate POC summaries + preset showcase index (#4 #7)

### DIFF
--- a/docs/poc/POC-SUMMARY-INDEX.md
+++ b/docs/poc/POC-SUMMARY-INDEX.md
@@ -1,0 +1,41 @@
+# AgentHabitat POC Summary Index
+
+This index consolidates the current POC milestone summaries and proof assets for quick review.
+
+## Milestone Summaries
+
+- [Blazor UI Summary](./BLAZOR-UI-SUMMARY.md)
+- [Environment v2 Summary](./ENVIRONMENT-V2-SUMMARY.md)
+- [Redecoration v1 Summary](./REDECORATION-V1-SUMMARY.md)
+- [Door Generation v1 Summary](./DOOR-GENERATION-V1-SUMMARY.md)
+
+## Preset Showcase (Before/After)
+
+### Startup Office
+- Before: `worldgen/preset-startup-office.png`
+- After: `worldgen/preset-startup-office-v2.png`
+
+### Research Lab
+- Before: `worldgen/preset-research-lab.png`
+- After: `worldgen/preset-research-lab-v2.png`
+
+### Cozy Studio
+- Before: `worldgen/preset-cozy-studio.png`
+- After: `worldgen/preset-cozy-studio-v2.png`
+
+### Corporate HQ
+- Before: `worldgen/env-v2-retro.png`
+- After: `worldgen/preset-corporate-hq-v2.png`
+
+## Core Proof Strips
+
+- Redecoration proof set: `screenshots/01-world-overview.png` → `screenshots/05-invariant-pass-banner.png`
+- Door semantics proof set: `screenshots/09-doors-all-open.png` → `screenshots/12-traversal-blocked.png`
+- Living habitat join proof: `screenshots/16-before-join.png` → `screenshots/18-after-join-2.png`
+
+## Current Headline Status
+
+- Environment v2: complete and packaged
+- Redecoration v1: complete and packaged
+- Door Generation v1 + weighting tuning: complete and packaged
+- Test health: green in latest reports


### PR DESCRIPTION
## Summary
- Adds docs/poc/POC-SUMMARY-INDEX.md as the single entry point for milestone docs.
- Links packaged summaries:
  - Blazor UI
  - Environment v2
  - Redecoration v1
  - Door Generation v1
- Adds compact per-preset before/after references.
- Lists core proof strips used in Discord show-and-tell.

## Why
This closes docs/showcase backlog cleanup and gives one navigable documentation surface.

## Validation
- Docs-only change
- No code/test impact

Closes #4
Closes #7