### PR TITLE
[AgentHabitat] add CI, CodeQL, dependabot actions coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,19 @@
 # Keep dependency PRs grouped and delayed for at least 48 hours so newly published packages age before adoption.
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  dotnet:
+    name: .NET Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore AgentHabitat.sln
+
+      - name: Build
+        run: dotnet build AgentHabitat.sln --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test AgentHabitat.sln --no-build --configuration Release --verbosity normal

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, csharp]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET (C# only)
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jerrett Davis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- **ci.yml** — dotnet restore/build/test on push+PR to `main`; targets net10.0 (Blazor WASM + Core library + xUnit tests). JS `test` script is a stub (`exit 1`) and `lint`/`build` scripts don't exist, so no JS job added.
- **codeql.yml** — CodeQL for `javascript-typescript` and `csharp` on push/PR + weekly schedule (codeql-action v3); matrix strategy covers both languages.
- **dependabot.yml** — added `github-actions` ecosystem entry (weekly, Monday); existing `nuget` and `npm` entries preserved.
- **LICENSE** — MIT 2026, Jerrett Davis (matches PatternKit sibling).

## Package manager & .NET component

- Package manager: **npm** (package-lock.json present)
- .NET component: **real and substantive** — `net10.0` Blazor WASM frontend (`AgentHabitat.Web`) + `AgentHabitat.Core` class library + `AgentHabitat.Core.Tests` (xUnit)

## Test plan

- [ ] CI job: `dotnet restore` / `dotnet build --configuration Release` / `dotnet test` all pass on ubuntu-latest
- [ ] CodeQL jobs: both `javascript-typescript` and `csharp` analyses complete without errors
- [ ] Dependabot picks up github-actions updates weekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)